### PR TITLE
Update Java parser API

### DIFF
--- a/java/src/com/swiftnav/sbp/client/MessageTable.java
+++ b/java/src/com/swiftnav/sbp/client/MessageTable.java
@@ -15,26 +15,6 @@ import com.swiftnav.sbp.SBPBinaryException;
 import com.swiftnav.sbp.SBPMessage;
 import com.swiftnav.sbp.SBPMessage.Builder;
 import com.swiftnav.sbp.SBPMessage.Parser;
-import com.swiftnav.sbp.system.MsgStartup;
-import com.swiftnav.sbp.system.MsgDgnssStatus;
-import com.swiftnav.sbp.system.MsgHeartbeat;
-import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeReq;
-import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeResp;
-import com.swiftnav.sbp.bootload.MsgBootloaderJumpToApp;
-import com.swiftnav.sbp.bootload.MsgNapDeviceDnaReq;
-import com.swiftnav.sbp.bootload.MsgNapDeviceDnaResp;
-import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeDepA;
-import com.swiftnav.sbp.user.MsgUserData;
-import com.swiftnav.sbp.flash.MsgFlashProgram;
-import com.swiftnav.sbp.flash.MsgFlashDone;
-import com.swiftnav.sbp.flash.MsgFlashReadReq;
-import com.swiftnav.sbp.flash.MsgFlashReadResp;
-import com.swiftnav.sbp.flash.MsgFlashErase;
-import com.swiftnav.sbp.flash.MsgStmFlashLockSector;
-import com.swiftnav.sbp.flash.MsgStmFlashUnlockSector;
-import com.swiftnav.sbp.flash.MsgStmUniqueIdReq;
-import com.swiftnav.sbp.flash.MsgStmUniqueIdResp;
-import com.swiftnav.sbp.flash.MsgM25FlashWriteStatus;
 import com.swiftnav.sbp.navigation.MsgGPSTime;
 import com.swiftnav.sbp.navigation.MsgUtcTime;
 import com.swiftnav.sbp.navigation.MsgDops;
@@ -79,14 +59,33 @@ import com.swiftnav.sbp.observation.MsgGroupDelayDepA;
 import com.swiftnav.sbp.observation.MsgGroupDelay;
 import com.swiftnav.sbp.observation.MsgAlmanacGPS;
 import com.swiftnav.sbp.observation.MsgAlmanacGlo;
-import com.swiftnav.sbp.settings.MsgSettingsSave;
-import com.swiftnav.sbp.settings.MsgSettingsWrite;
-import com.swiftnav.sbp.settings.MsgSettingsReadReq;
-import com.swiftnav.sbp.settings.MsgSettingsReadResp;
-import com.swiftnav.sbp.settings.MsgSettingsReadByIndexReq;
-import com.swiftnav.sbp.settings.MsgSettingsReadByIndexResp;
-import com.swiftnav.sbp.settings.MsgSettingsReadByIndexDone;
-import com.swiftnav.sbp.settings.MsgSettingsRegister;
+import com.swiftnav.sbp.imu.MsgImuRaw;
+import com.swiftnav.sbp.imu.MsgImuAux;
+import com.swiftnav.sbp.user.MsgUserData;
+import com.swiftnav.sbp.ext_events.MsgExtEvent;
+import com.swiftnav.sbp.acquisition.MsgAcqResult;
+import com.swiftnav.sbp.acquisition.MsgAcqResultDepB;
+import com.swiftnav.sbp.acquisition.MsgAcqResultDepA;
+import com.swiftnav.sbp.acquisition.MsgAcqSvProfile;
+import com.swiftnav.sbp.tracking.MsgTrackingStateDetailed;
+import com.swiftnav.sbp.tracking.MsgTrackingState;
+import com.swiftnav.sbp.tracking.MsgTrackingIq;
+import com.swiftnav.sbp.tracking.MsgTrackingStateDepA;
+import com.swiftnav.sbp.tracking.MsgTrackingStateDepB;
+import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeReq;
+import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeResp;
+import com.swiftnav.sbp.bootload.MsgBootloaderJumpToApp;
+import com.swiftnav.sbp.bootload.MsgNapDeviceDnaReq;
+import com.swiftnav.sbp.bootload.MsgNapDeviceDnaResp;
+import com.swiftnav.sbp.bootload.MsgBootloaderHandshakeDepA;
+import com.swiftnav.sbp.ndb.MsgNdbEvent;
+import com.swiftnav.sbp.file_io.MsgFileioReadReq;
+import com.swiftnav.sbp.file_io.MsgFileioReadResp;
+import com.swiftnav.sbp.file_io.MsgFileioReadDirReq;
+import com.swiftnav.sbp.file_io.MsgFileioReadDirResp;
+import com.swiftnav.sbp.file_io.MsgFileioRemove;
+import com.swiftnav.sbp.file_io.MsgFileioWriteReq;
+import com.swiftnav.sbp.file_io.MsgFileioWriteResp;
 import com.swiftnav.sbp.piksi.MsgAlmanac;
 import com.swiftnav.sbp.piksi.MsgSetTime;
 import com.swiftnav.sbp.piksi.MsgReset;
@@ -107,74 +106,35 @@ import com.swiftnav.sbp.piksi.MsgCommandOutput;
 import com.swiftnav.sbp.piksi.MsgNetworkStateReq;
 import com.swiftnav.sbp.piksi.MsgNetworkStateResp;
 import com.swiftnav.sbp.piksi.MsgSpecan;
+import com.swiftnav.sbp.flash.MsgFlashProgram;
+import com.swiftnav.sbp.flash.MsgFlashDone;
+import com.swiftnav.sbp.flash.MsgFlashReadReq;
+import com.swiftnav.sbp.flash.MsgFlashReadResp;
+import com.swiftnav.sbp.flash.MsgFlashErase;
+import com.swiftnav.sbp.flash.MsgStmFlashLockSector;
+import com.swiftnav.sbp.flash.MsgStmFlashUnlockSector;
+import com.swiftnav.sbp.flash.MsgStmUniqueIdReq;
+import com.swiftnav.sbp.flash.MsgStmUniqueIdResp;
+import com.swiftnav.sbp.flash.MsgM25FlashWriteStatus;
 import com.swiftnav.sbp.logging.MsgLog;
 import com.swiftnav.sbp.logging.MsgFwd;
 import com.swiftnav.sbp.logging.MsgTweet;
 import com.swiftnav.sbp.logging.MsgPrintDep;
-import com.swiftnav.sbp.tracking.MsgTrackingStateDetailed;
-import com.swiftnav.sbp.tracking.MsgTrackingState;
-import com.swiftnav.sbp.tracking.MsgTrackingIq;
-import com.swiftnav.sbp.tracking.MsgTrackingStateDepA;
-import com.swiftnav.sbp.tracking.MsgTrackingStateDepB;
-import com.swiftnav.sbp.imu.MsgImuRaw;
-import com.swiftnav.sbp.imu.MsgImuAux;
-import com.swiftnav.sbp.acquisition.MsgAcqResult;
-import com.swiftnav.sbp.acquisition.MsgAcqResultDepB;
-import com.swiftnav.sbp.acquisition.MsgAcqResultDepA;
-import com.swiftnav.sbp.acquisition.MsgAcqSvProfile;
-import com.swiftnav.sbp.file_io.MsgFileioReadReq;
-import com.swiftnav.sbp.file_io.MsgFileioReadResp;
-import com.swiftnav.sbp.file_io.MsgFileioReadDirReq;
-import com.swiftnav.sbp.file_io.MsgFileioReadDirResp;
-import com.swiftnav.sbp.file_io.MsgFileioRemove;
-import com.swiftnav.sbp.file_io.MsgFileioWriteReq;
-import com.swiftnav.sbp.file_io.MsgFileioWriteResp;
-import com.swiftnav.sbp.ndb.MsgNdbEvent;
-import com.swiftnav.sbp.ext_events.MsgExtEvent;
+import com.swiftnav.sbp.system.MsgStartup;
+import com.swiftnav.sbp.system.MsgDgnssStatus;
+import com.swiftnav.sbp.system.MsgHeartbeat;
+import com.swiftnav.sbp.settings.MsgSettingsSave;
+import com.swiftnav.sbp.settings.MsgSettingsWrite;
+import com.swiftnav.sbp.settings.MsgSettingsReadReq;
+import com.swiftnav.sbp.settings.MsgSettingsReadResp;
+import com.swiftnav.sbp.settings.MsgSettingsReadByIndexReq;
+import com.swiftnav.sbp.settings.MsgSettingsReadByIndexResp;
+import com.swiftnav.sbp.settings.MsgSettingsReadByIndexDone;
+import com.swiftnav.sbp.settings.MsgSettingsRegister;
 
 final class MessageTable {
     static SBPMessage dispatch(SBPMessage msg) throws SBPBinaryException {
         switch (msg.type) {
-            case MsgStartup.TYPE:
-                return new MsgStartup(msg);
-            case MsgDgnssStatus.TYPE:
-                return new MsgDgnssStatus(msg);
-            case MsgHeartbeat.TYPE:
-                return new MsgHeartbeat(msg);
-            case MsgBootloaderHandshakeReq.TYPE:
-                return new MsgBootloaderHandshakeReq(msg);
-            case MsgBootloaderHandshakeResp.TYPE:
-                return new MsgBootloaderHandshakeResp(msg);
-            case MsgBootloaderJumpToApp.TYPE:
-                return new MsgBootloaderJumpToApp(msg);
-            case MsgNapDeviceDnaReq.TYPE:
-                return new MsgNapDeviceDnaReq(msg);
-            case MsgNapDeviceDnaResp.TYPE:
-                return new MsgNapDeviceDnaResp(msg);
-            case MsgBootloaderHandshakeDepA.TYPE:
-                return new MsgBootloaderHandshakeDepA(msg);
-            case MsgUserData.TYPE:
-                return new MsgUserData(msg);
-            case MsgFlashProgram.TYPE:
-                return new MsgFlashProgram(msg);
-            case MsgFlashDone.TYPE:
-                return new MsgFlashDone(msg);
-            case MsgFlashReadReq.TYPE:
-                return new MsgFlashReadReq(msg);
-            case MsgFlashReadResp.TYPE:
-                return new MsgFlashReadResp(msg);
-            case MsgFlashErase.TYPE:
-                return new MsgFlashErase(msg);
-            case MsgStmFlashLockSector.TYPE:
-                return new MsgStmFlashLockSector(msg);
-            case MsgStmFlashUnlockSector.TYPE:
-                return new MsgStmFlashUnlockSector(msg);
-            case MsgStmUniqueIdReq.TYPE:
-                return new MsgStmUniqueIdReq(msg);
-            case MsgStmUniqueIdResp.TYPE:
-                return new MsgStmUniqueIdResp(msg);
-            case MsgM25FlashWriteStatus.TYPE:
-                return new MsgM25FlashWriteStatus(msg);
             case MsgGPSTime.TYPE:
                 return new MsgGPSTime(msg);
             case MsgUtcTime.TYPE:
@@ -263,22 +223,60 @@ final class MessageTable {
                 return new MsgAlmanacGPS(msg);
             case MsgAlmanacGlo.TYPE:
                 return new MsgAlmanacGlo(msg);
-            case MsgSettingsSave.TYPE:
-                return new MsgSettingsSave(msg);
-            case MsgSettingsWrite.TYPE:
-                return new MsgSettingsWrite(msg);
-            case MsgSettingsReadReq.TYPE:
-                return new MsgSettingsReadReq(msg);
-            case MsgSettingsReadResp.TYPE:
-                return new MsgSettingsReadResp(msg);
-            case MsgSettingsReadByIndexReq.TYPE:
-                return new MsgSettingsReadByIndexReq(msg);
-            case MsgSettingsReadByIndexResp.TYPE:
-                return new MsgSettingsReadByIndexResp(msg);
-            case MsgSettingsReadByIndexDone.TYPE:
-                return new MsgSettingsReadByIndexDone(msg);
-            case MsgSettingsRegister.TYPE:
-                return new MsgSettingsRegister(msg);
+            case MsgImuRaw.TYPE:
+                return new MsgImuRaw(msg);
+            case MsgImuAux.TYPE:
+                return new MsgImuAux(msg);
+            case MsgUserData.TYPE:
+                return new MsgUserData(msg);
+            case MsgExtEvent.TYPE:
+                return new MsgExtEvent(msg);
+            case MsgAcqResult.TYPE:
+                return new MsgAcqResult(msg);
+            case MsgAcqResultDepB.TYPE:
+                return new MsgAcqResultDepB(msg);
+            case MsgAcqResultDepA.TYPE:
+                return new MsgAcqResultDepA(msg);
+            case MsgAcqSvProfile.TYPE:
+                return new MsgAcqSvProfile(msg);
+            case MsgTrackingStateDetailed.TYPE:
+                return new MsgTrackingStateDetailed(msg);
+            case MsgTrackingState.TYPE:
+                return new MsgTrackingState(msg);
+            case MsgTrackingIq.TYPE:
+                return new MsgTrackingIq(msg);
+            case MsgTrackingStateDepA.TYPE:
+                return new MsgTrackingStateDepA(msg);
+            case MsgTrackingStateDepB.TYPE:
+                return new MsgTrackingStateDepB(msg);
+            case MsgBootloaderHandshakeReq.TYPE:
+                return new MsgBootloaderHandshakeReq(msg);
+            case MsgBootloaderHandshakeResp.TYPE:
+                return new MsgBootloaderHandshakeResp(msg);
+            case MsgBootloaderJumpToApp.TYPE:
+                return new MsgBootloaderJumpToApp(msg);
+            case MsgNapDeviceDnaReq.TYPE:
+                return new MsgNapDeviceDnaReq(msg);
+            case MsgNapDeviceDnaResp.TYPE:
+                return new MsgNapDeviceDnaResp(msg);
+            case MsgBootloaderHandshakeDepA.TYPE:
+                return new MsgBootloaderHandshakeDepA(msg);
+            case MsgNdbEvent.TYPE:
+                return new MsgNdbEvent(msg);
+            case MsgFileioReadReq.TYPE:
+                return new MsgFileioReadReq(msg);
+            case MsgFileioReadResp.TYPE:
+                return new MsgFileioReadResp(msg);
+            case MsgFileioReadDirReq.TYPE:
+                return new MsgFileioReadDirReq(msg);
+            case MsgFileioReadDirResp.TYPE:
+                return new MsgFileioReadDirResp(msg);
+            case MsgFileioRemove.TYPE:
+                return new MsgFileioRemove(msg);
+            case MsgFileioWriteReq.TYPE:
+                return new MsgFileioWriteReq(msg);
+            case MsgFileioWriteResp.TYPE:
+                return new MsgFileioWriteResp(msg);
             case MsgAlmanac.TYPE:
                 return new MsgAlmanac(msg);
             case MsgSetTime.TYPE:
@@ -319,6 +317,26 @@ final class MessageTable {
                 return new MsgNetworkStateResp(msg);
             case MsgSpecan.TYPE:
                 return new MsgSpecan(msg);
+            case MsgFlashProgram.TYPE:
+                return new MsgFlashProgram(msg);
+            case MsgFlashDone.TYPE:
+                return new MsgFlashDone(msg);
+            case MsgFlashReadReq.TYPE:
+                return new MsgFlashReadReq(msg);
+            case MsgFlashReadResp.TYPE:
+                return new MsgFlashReadResp(msg);
+            case MsgFlashErase.TYPE:
+                return new MsgFlashErase(msg);
+            case MsgStmFlashLockSector.TYPE:
+                return new MsgStmFlashLockSector(msg);
+            case MsgStmFlashUnlockSector.TYPE:
+                return new MsgStmFlashUnlockSector(msg);
+            case MsgStmUniqueIdReq.TYPE:
+                return new MsgStmUniqueIdReq(msg);
+            case MsgStmUniqueIdResp.TYPE:
+                return new MsgStmUniqueIdResp(msg);
+            case MsgM25FlashWriteStatus.TYPE:
+                return new MsgM25FlashWriteStatus(msg);
             case MsgLog.TYPE:
                 return new MsgLog(msg);
             case MsgFwd.TYPE:
@@ -327,46 +345,28 @@ final class MessageTable {
                 return new MsgTweet(msg);
             case MsgPrintDep.TYPE:
                 return new MsgPrintDep(msg);
-            case MsgTrackingStateDetailed.TYPE:
-                return new MsgTrackingStateDetailed(msg);
-            case MsgTrackingState.TYPE:
-                return new MsgTrackingState(msg);
-            case MsgTrackingIq.TYPE:
-                return new MsgTrackingIq(msg);
-            case MsgTrackingStateDepA.TYPE:
-                return new MsgTrackingStateDepA(msg);
-            case MsgTrackingStateDepB.TYPE:
-                return new MsgTrackingStateDepB(msg);
-            case MsgImuRaw.TYPE:
-                return new MsgImuRaw(msg);
-            case MsgImuAux.TYPE:
-                return new MsgImuAux(msg);
-            case MsgAcqResult.TYPE:
-                return new MsgAcqResult(msg);
-            case MsgAcqResultDepB.TYPE:
-                return new MsgAcqResultDepB(msg);
-            case MsgAcqResultDepA.TYPE:
-                return new MsgAcqResultDepA(msg);
-            case MsgAcqSvProfile.TYPE:
-                return new MsgAcqSvProfile(msg);
-            case MsgFileioReadReq.TYPE:
-                return new MsgFileioReadReq(msg);
-            case MsgFileioReadResp.TYPE:
-                return new MsgFileioReadResp(msg);
-            case MsgFileioReadDirReq.TYPE:
-                return new MsgFileioReadDirReq(msg);
-            case MsgFileioReadDirResp.TYPE:
-                return new MsgFileioReadDirResp(msg);
-            case MsgFileioRemove.TYPE:
-                return new MsgFileioRemove(msg);
-            case MsgFileioWriteReq.TYPE:
-                return new MsgFileioWriteReq(msg);
-            case MsgFileioWriteResp.TYPE:
-                return new MsgFileioWriteResp(msg);
-            case MsgNdbEvent.TYPE:
-                return new MsgNdbEvent(msg);
-            case MsgExtEvent.TYPE:
-                return new MsgExtEvent(msg);
+            case MsgStartup.TYPE:
+                return new MsgStartup(msg);
+            case MsgDgnssStatus.TYPE:
+                return new MsgDgnssStatus(msg);
+            case MsgHeartbeat.TYPE:
+                return new MsgHeartbeat(msg);
+            case MsgSettingsSave.TYPE:
+                return new MsgSettingsSave(msg);
+            case MsgSettingsWrite.TYPE:
+                return new MsgSettingsWrite(msg);
+            case MsgSettingsReadReq.TYPE:
+                return new MsgSettingsReadReq(msg);
+            case MsgSettingsReadResp.TYPE:
+                return new MsgSettingsReadResp(msg);
+            case MsgSettingsReadByIndexReq.TYPE:
+                return new MsgSettingsReadByIndexReq(msg);
+            case MsgSettingsReadByIndexResp.TYPE:
+                return new MsgSettingsReadByIndexResp(msg);
+            case MsgSettingsReadByIndexDone.TYPE:
+                return new MsgSettingsReadByIndexDone(msg);
+            case MsgSettingsRegister.TYPE:
+                return new MsgSettingsRegister(msg);
         }
         return msg;
     }


### PR DESCRIPTION
The architecture of the Java parser is updated to be consistent with the
SnapCam project.  This includes development of the parser which does not
execute its own thread, but instead ingests supplied serial data a byte at
the time, and returns the parsed message once an entire message is
received.